### PR TITLE
Queue deep link requests

### DIFF
--- a/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
+++ b/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
@@ -26,11 +26,11 @@ public class MVVMCAppCoordinator: NSObject {
     }
     
     public func start() {
-        isStarted = true
         // TODO: Do not start all modules directly at the beginning
         for module in modules {
             module.coordinator.start()
         }
+        isStarted = true
         triggerQueuedDeepLinks()
     }
     

--- a/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
+++ b/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
@@ -36,6 +36,7 @@ public class MVVMCAppCoordinator: NSObject {
     
     private func triggerQueuedDeepLinks() {
         queuedDeepLinks.forEach { self.deepLink(chain: $0.0, selectedTab: $0.1) }
+        queuedDeepLinks.removeAll()
     }
 
     func setupModules(for factories: [MVVMCTabBarFactoryProtocol]) {

--- a/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
+++ b/Atlas/Atlas/Coordinators/MVVMCAppCoordinator.swift
@@ -21,11 +21,10 @@ public class MVVMCAppCoordinator: NSObject {
         
         tabBar.delegate = self
         setupModules(for: factories)
-
-        window.rootViewController = tabBar
     }
     
     public func start() {
+        window.rootViewController = tabBar
         // TODO: Do not start all modules directly at the beginning
         for module in modules {
             module.coordinator.start()


### PR DESCRIPTION
# What changed?

There is now a little deep link queue. Everytime you call the function to request a deep link it checks now if the coordinator is already started. If not the deep link is queued. After `start()` was called the queue is triggered. This avoids unwanted side effects at App startup time.