### PR TITLE
Fix deeplink to already presented modal view

### DIFF
--- a/Atlas/Atlas/Coordinators/MVVMCNavigationAppCoordinator.swift
+++ b/Atlas/Atlas/Coordinators/MVVMCNavigationAppCoordinator.swift
@@ -58,15 +58,16 @@ public class MVVMCNavigationAppCoordinator: NSObject, MVVMCAppCoordinator {
         }
         
         guard let module = modules.first else { return }
-        module.navigationController.dismiss(animated: false, completion: nil)
-        module.navigationController.popToRootViewController(animated: false)
-        var coordinator: MVVMCCoordinatorProtocol? = module.coordinator
-
-        for request in chain {
-            coordinator?.request(navigation: request, withData: [:], animated: false)
-            coordinator = coordinator?.targetCoordinator
-        }
-        completion?()
+        module.navigationController.dismiss(animated: false, completion: {
+            module.navigationController.popToRootViewController(animated: false)
+            var coordinator: MVVMCCoordinatorProtocol? = module.coordinator
+            
+            for request in chain {
+                coordinator?.request(navigation: request, withData: [:], animated: false)
+                coordinator = coordinator?.targetCoordinator
+            }
+            completion?()
+        })
     }
     
     public func display(request: MVVMCNavigationRequest, animated: Bool) {

--- a/Atlas/Atlas/Coordinators/MVVMCTabbedAppCoordinator.swift
+++ b/Atlas/Atlas/Coordinators/MVVMCTabbedAppCoordinator.swift
@@ -72,16 +72,17 @@ public class MVVMCTabbedAppCoordinator: NSObject, MVVMCAppCoordinator {
         }
         guard let selectedTab = selectedTab else { return }
         let module = modules[selectedTab]
-        module.navigationController.dismiss(animated: false, completion: nil)
-        tabBar.selectedIndex = selectedTab
-        module.navigationController.popToRootViewController(animated: false)
-        var coordinator: MVVMCCoordinatorProtocol? = module.coordinator
-
-        for request in chain {
-            coordinator?.request(navigation: request, withData: [:], animated: false)
-            coordinator = coordinator?.targetCoordinator
-        }
-        completion?()
+        module.navigationController.dismiss(animated: false, completion: {
+            self.tabBar.selectedIndex = selectedTab
+            module.navigationController.popToRootViewController(animated: false)
+            var coordinator: MVVMCCoordinatorProtocol? = module.coordinator
+            
+            for request in chain {
+                coordinator?.request(navigation: request, withData: [:], animated: false)
+                coordinator = coordinator?.targetCoordinator
+            }
+            completion?()
+        })
     }
     
     public func display(request: MVVMCNavigationRequest, animated: Bool) {


### PR DESCRIPTION
When we do not wait for the dismiss of the currently presented modal, the coordinator will try to present on this modal view which is dismissed shortly after, resulting in our view to not be displayed.